### PR TITLE
windows release is zip

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,4 +18,4 @@ nfpm:
 archive:
   format_overrides:
     - goos: windows
-      format: binary
+      format: zip


### PR DESCRIPTION
goreleaser don't support (or have a bug) in binary format override, use zip instead of binary for windows